### PR TITLE
bugfix: remove conversion of X-RateLimit-Reset header to Date object

### DIFF
--- a/lib/stocktwits.js
+++ b/lib/stocktwits.js
@@ -79,7 +79,7 @@ StockTwits.prototype.get = function (api, params, cb) {
             }
             res.limit = parseInt(res.headers['x-ratelimit-limit']||0);
             res.remaining = parseInt(res.headers['x-ratelimit-remaining']||0);
-            res.reset = new Date(res.headers['x-ratelimit-reset']||0);
+            res.reset = parseInt(res.headers['x-ratelimit-reset']||0);
 
             if (!error && res.body.response.status != 200) return cb(res.body, res);
             cb(error, res);
@@ -126,8 +126,8 @@ StockTwits.prototype.post = function (api, params, data, cb) {
             }
             res.limit = parseInt(res.headers['x-ratelimit-limit']||0);
             res.remaining = parseInt(res.headers['x-ratelimit-remaining']||0);
-            res.reset = new Date(res.headers['x-ratelimit-reset']||0);
-            
+            res.reset = parseInt(res.headers['x-ratelimit-reset']||0);
+
             if (!error && res.body.response.status != 200) return cb(res.body, res);
             cb(error, res);
         });


### PR DESCRIPTION
I know it's been a long time since the last commit but appreciate your work and effort here @simov.

This patch removes the conversion of the X-RateLimit-Reset header to a Date object; the reason is two fold:

* the stocktwits api returns a unix timestamp, which is easier to work with / convert to other formats later.
* there's actually a bug here because for the X-RateLimit-Reset header string to be passed to `new Date()`, it must first be parsed to an int; eg `new Date(parseInt(res.headers['x-ratelimit-reset']||0))`.